### PR TITLE
Configure Dependabot ignore rules for Ktor and Gradle wrapper

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: [ "version-update:semver-patch" ]
+      - dependency-name: "io.ktor:*"
+      - dependency-name: "io.ktor.plugin"
+      - dependency-name: "gradle-wrapper"


### PR DESCRIPTION
This keeps Dependabot from proposing updates for dependencies we intentionally want to hold back. The project is pinned to Ktor 3.1.1 and the matching `io.ktor.plugin` version, and it should also stop opening wrapper upgrade PRs.

## What changed
- ignore all `io.ktor:*` version updates so `ktorVersion` stays on 3.1.1
- ignore `io.ktor.plugin` updates so the Gradle plugin stays on 3.1.1
- ignore `gradle-wrapper` updates

This only changes Dependabot configuration; application code and runtime behavior are unchanged.